### PR TITLE
Fixing bower components directory; adding tests

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -71,8 +71,8 @@ module.exports = function(grunt) {
 			compile : {
 				options : {
 					paths: {
-						can      : 'bower_components/canjs/amd/can',
-						jquery   : 'bower_components/jquery/jquery',
+						can      : 'app/bower_components/canjs/amd/can',
+						jquery   : 'app/bower_components/jquery/jquery',
 						mustache : '.build/mustache',
 						ejs      : '.build/ejs'
 					},
@@ -92,7 +92,7 @@ module.exports = function(grunt) {
 		views.forEach(function(view){
 			var filename = view.expression.arguments[0].value;
 			generatedViews[filename] = escodegen.generate(view);
-			
+
 		})
 		fs.writeFileSync('.build/views.json', JSON.stringify(generatedViews));
 	})
@@ -117,6 +117,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-requirejs');
 	grunt.loadNpmTasks('grunt-exec');
 	grunt.registerTask('default', 'build');
-	
+
 
 };

--- a/test/test-none.js
+++ b/test/test-none.js
@@ -11,7 +11,7 @@ describe('CanJS generator without RequireJS', function () {
       if (err) {
         return done(err);
       }
-      
+
       this.app = helpers.createGenerator('canjs:app', [
         '../../app'
       ]);
@@ -35,7 +35,8 @@ describe('CanJS generator without RequireJS', function () {
       'bower.json',
       ['foo.html', /can\.jquery\.js/],
       'foo.js',
-      'package.json'
+      'package.json',
+      'app/bower_components/canjs/.bower.json'
     ];
 
     this.app.run({}, function () {
@@ -52,7 +53,7 @@ describe('CanJS generator without RequireJS', function () {
         name : 'models/user',
         generateFixture : 'y'
       })
-      
+
       this.app.run({}, function(){
         model.run([], function(){
           helpers.assertFiles([

--- a/test/test-requirejs.js
+++ b/test/test-requirejs.js
@@ -11,7 +11,7 @@ describe('CanJS generator with RequireJS', function () {
       if (err) {
         return done(err);
       }
-      
+
       this.app = helpers.createGenerator('canjs:app', [
         '../../app'
       ]);
@@ -36,7 +36,8 @@ describe('CanJS generator with RequireJS', function () {
       ['foo.html', /require\.js/],
       ['foo.js', /requirejs/],
       'package.json',
-      'requirejsconfig.js'
+      'requirejsconfig.js',
+      'app/bower_components/canjs/.bower.json'
     ];
 
     this.app.run({}, function () {


### PR DESCRIPTION
The requirejs config is expecting bower_components to be in a different directory, and so grunt throws an error when first generating a canjs app using this generator.
